### PR TITLE
feat: RootQuerys: comment()

### DIFF
--- a/graphql/resolvers/Comment.js
+++ b/graphql/resolvers/Comment.js
@@ -13,6 +13,19 @@ module.exports = {
   userCanEdit: ({ userId }, args, { user }) =>
     userId === user.id,
 
+  comments: async ({ id }, args, { pgdb }) => {
+    // TODO: Honor these options
+    // const { orderBy, after, take } = args
+
+    const comments = await pgdb.public.comments.find({ parentId: id })
+
+    return {
+      totalCount: comments.length,
+      pageInfo: {hasNextPage: false},
+      nodes: comments
+    }
+  },
+
   userVote: ({ votes }, args, { user }) => {
     const userVote = votes.find(v => v.userId === user.id)
     if (userVote) {

--- a/graphql/resolvers/_RootQuerys/comment.js
+++ b/graphql/resolvers/_RootQuerys/comment.js
@@ -1,0 +1,2 @@
+module.exports = async (_, { id }, { pgdb }) =>
+  pgdb.public.comments.findOne({ id })

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -14,6 +14,7 @@ type RootQuerys {
   publicUser(id: ID!): PublicUser
   discussions: [Discussion!]!
   discussion(id: ID!): Discussion
+  comment(id: ID!): Comment
 }
 
 type RootMutations {
@@ -261,7 +262,7 @@ type Comment {
   discussion: Discussion!
   id: ID!
   parent: Comment
-  comments: CommentConnection!
+  comments(orderBy: OrderDirection, after: String, first: Int): CommentConnection!
   # maybe becomes mdast/JSON later
   content: String!
   upVotes: Int!


### PR DESCRIPTION
A new root query to fetch a particular comment, and resolver for the `comments` field of a `Comment` (TODO: honor its args).