### PR TITLE
newsletter subscriptions: if get fails, return a graceful fallback response with all supported interests

### DIFF
--- a/lib/mailchimp/getNewsletterSettings.js
+++ b/lib/mailchimp/getNewsletterSettings.js
@@ -35,7 +35,7 @@ module.exports.getNewsletterSettings = async (userId, context) => {
           { data }
         )
         interests = supportedInterestIds.reduce(
-          (result, item, index, array) => {
+          (result, item) => {
             result[item] = false
             return result
           },

--- a/lib/mailchimp/getNewsletterSettings.js
+++ b/lib/mailchimp/getNewsletterSettings.js
@@ -28,25 +28,37 @@ module.exports.getNewsletterSettings = async (userId, context) => {
   })
     .then(response => response.json())
     .then(data => {
+      let interests
       if (data.status >= 400) {
-        console.error('getNewsletterProfile failed', { data })
-        throw new Error(t('api/newsletters/get/failed'))
+        console.error(
+          'getNewsletterProfile failed, returning fallback response',
+          { data }
+        )
+        interests = supportedInterestIds.reduce(
+          (result, item, index, array) => {
+            result[item] = false
+            return result
+          },
+          {}
+        )
+      } else {
+        interests = data.interests
       }
 
       const subscriptions = []
       supportedInterestIds.forEach(interestId => {
-        if (interestId in data.interests) {
+        if (interestId in interests) {
           subscriptions.push(
             NewsletterSubscription(
               userId,
               interestId,
-              data.status !== 'subscribed' ? false : data.interests[interestId],
+              data.status !== 'subscribed' ? false : interests[interestId],
               roles
             )
           )
         }
       })
-      return {status: data.status, subscriptions}
+      return { status: data.status, subscriptions }
     })
     .catch(error => {
       console.error('getNewsletterProfile failed', { error })


### PR DESCRIPTION
will result in this UI when get fails:
<img width="888" alt="screen shot 2018-01-14 at 03 46 52" src="https://user-images.githubusercontent.com/23520051/34912290-c6812064-f8dd-11e7-9163-fcc6c7c9aabd.png">
