### PR TITLE
resolve with webp false

### DIFF
--- a/graphql/resolvers/_mutations/requestPreview.js
+++ b/graphql/resolvers/_mutations/requestPreview.js
@@ -40,14 +40,17 @@ module.exports = async (_, args, context) => {
     throw new Error(t('api/preview/mail/404'))
   }
   // resolve Document
-  const urlPrefix = FRONTEND_BASE_URL
-  const searchString = '?' + querystring.stringify({
-    'utm_source': 'newsletter',
-    'utm_medium': 'email',
-    'utm_campaign': PREVIEW_MAIL_REPO_ID
-  })
-  doc.content = DocResolver.content(doc, { urlPrefix, searchString }, context)
-  doc.meta = DocResolver.meta(doc, { urlPrefix, searchString }, context)
+  const docResolverArgs = {
+    urlPrefix: FRONTEND_BASE_URL,
+    searchString: '?' + querystring.stringify({
+      'utm_source': 'newsletter',
+      'utm_medium': 'email',
+      'utm_campaign': PREVIEW_MAIL_REPO_ID
+    }),
+    webp: false
+  }
+  doc.content = DocResolver.content(doc, docResolverArgs, context)
+  doc.meta = DocResolver.meta(doc, docResolverArgs, context)
   const html = getHTML(doc)
 
   await sendMail({


### PR DESCRIPTION
Currently preview mails are send with [webp suffix if requested in chrome](https://piratinnen.slack.com/files/U47966JHH/F91HTHGTF/bildschirmfoto_2018-01-31_um_11.09.09.png). This suppresses webp for preview mails.

Depends on https://github.com/orbiting/backend-modules/pull/34